### PR TITLE
small typo correction in getOutputSetOfTomograms in tomoReconstruction

### DIFF
--- a/novactf/protocols/protocol_tomoReconstruction.py
+++ b/novactf/protocols/protocol_tomoReconstruction.py
@@ -283,7 +283,7 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
         else:
             outputSetOfTomograms = self._createSetOfTomograms()
             outputSetOfTomograms.copyInfo(self.protTomoCtfDefocus.get().getInputSetOfTiltSeries())
-            outputSetOfTomograms.setStreamState(pw.objects.Set.STREAM_OPEN)
+            outputSetOfTomograms.setStreamState(pw.object.Set.STREAM_OPEN)
             self._defineOutputs(outputSetOfTomograms=outputSetOfTomograms)
             self._defineSourceRelation(self.protTomoCtfDefocus.get().getInputSetOfTiltSeries(), outputSetOfTomograms)
 


### PR DESCRIPTION
This PR includes:

- Small typo correction in getOutputSetOfTomograms method in tomoReconstruction protocol: pw.objects->pw.object

This PR has been self-merged (no reviewers assigned)