### PR TITLE
Fi fixes workshop

### DIFF
--- a/novactf/protocols/protocol_tomoDefocus.py
+++ b/novactf/protocols/protocol_tomoDefocus.py
@@ -137,6 +137,7 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
 
     # -------------------------- INSERT steps functions ---------------------
     def _insertAllSteps(self):
+        self.numberOfIntermediateStacks = List([])
 
         for ts in self.inputSetOfTiltSeries.get():
             self._insertFunctionStep(self.convertInputStep,

--- a/novactf/protocols/protocol_tomoReconstruction.py
+++ b/novactf/protocols/protocol_tomoReconstruction.py
@@ -265,15 +265,15 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
         imodPlugin.runImod(self, 'trimvol', argsTrimvol % paramsTrimvol)
 
     def createOutputStep(self, tsObjId):
-        ts = self.protTomoCtfDefocus.get().inputSetOfTiltSeries.get()[tsObjId]
+        with self._lock:
+            ts = self.protTomoCtfDefocus.get().inputSetOfTiltSeries.get()[tsObjId]
+            firstItem = ts.getFirstItem()
 
         tsId = ts.getTsId()
         angleMax = ts[ts.getSize()].getTiltAngle()
         angleStepAverage = self.getAngleStepFromSeries(ts)
 
         extraPrefix = self._getExtraPath(tsId)
-
-        firstItem = ts.getFirstItem().clone()
 
         """Remove intermediate files. Necessary for big sets of tilt-series"""
         # path.cleanPath(self._getTmpPath(tsId))

--- a/novactf/protocols/protocol_tomoReconstruction.py
+++ b/novactf/protocols/protocol_tomoReconstruction.py
@@ -209,12 +209,14 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
         Plugin.runNovactf(self, 'novaCTF', argsFilterProjections % paramsFilterProjections)
 
     def computeReconstructionStep(self, tsObjId):
-        ts = self.protTomoCtfDefocus.get().inputSetOfTiltSeries.get()[tsObjId]
+        with self._lock:
+            ts = self.protTomoCtfDefocus.get().inputSetOfTiltSeries.get()[tsObjId]
+            firstItem = ts.getFirstItem()
+
         tsId = ts.getTsId()
+
         extraPrefix = self._getExtraPath(tsId)
         tmpPrefix = self._getTmpPath(tsId)
-
-        firstItem = ts.getFirstItem()
 
         outputFileNameFlip = firstItem.parseFileName(suffix="_flip", extension=".mrc")
         outputFileName = firstItem.parseFileName(extension=".mrc")
@@ -263,7 +265,6 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
         imodPlugin.runImod(self, 'trimvol', argsTrimvol % paramsTrimvol)
 
     def createOutputStep(self, tsObjId):
-
         ts = self.protTomoCtfDefocus.get().inputSetOfTiltSeries.get()[tsObjId]
 
         tsId = ts.getTsId()

--- a/novactf/protocols/protocol_tomoReconstruction.py
+++ b/novactf/protocols/protocol_tomoReconstruction.py
@@ -276,7 +276,7 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
         extraPrefix = self._getExtraPath(tsId)
 
         """Remove intermediate files. Necessary for big sets of tilt-series"""
-        # path.cleanPath(self._getTmpPath(tsId))
+        path.cleanPath(self._getTmpPath(tsId))
 
         """Generate output set"""
         outputSetOfTomograms = self.getOutputSetOfTomograms()


### PR DESCRIPTION
This PR includes fixes for the scipion workshop:

- NovaCTF defocus: empty list to avoid problems with copy and restart
- NovaCTF reconstruction: fixes for recursive use of cursors, remove tmp in execution time 