### PR TITLE
novactf refactoring

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,2 @@
 3.1:
-    - tbd
+    - refactoring

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,8 @@
 3.1:
-    - refactoring
+- fix defocus shift: should be passed in a file for ctf correction, and as a param for reconstruction
+- add gold erasing option
+- stack is aligned after ctf correction
+- fix test tilt axis value
+- add astigmatism validation
+- do not create new TomoAcquisition object
+- use mrc extension for all files

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,8 @@ master (8 Nov 2018)
 Protocols
 ---------
 
-* 3D ctf correction
+* compute defocus array
+* 3D CTF correction and reconstruction
 
 References
 ----------

--- a/novactf/__init__.py
+++ b/novactf/__init__.py
@@ -84,7 +84,7 @@ class Plugin(pwem.Plugin):
                        default=True)
 
     @classmethod
-    def runNovactf(cls, protocol, program, args, cwd=None):
+    def runNovactf(cls, protocol, program, args, **kwargs):
         """ Run NovaCTF command from a given protocol. """
         fullProgram = '%s/%s/%s' % (cls.getVar(NOVACTF_HOME), "novaCTF-master", program)
-        protocol.runJob(fullProgram, args, env=cls.getEnviron(), cwd=cwd)
+        protocol.runJob(fullProgram, args, env=cls.getEnviron(), **kwargs)

--- a/novactf/protocols/protocol_tomoDefocus.py
+++ b/novactf/protocols/protocol_tomoDefocus.py
@@ -124,7 +124,7 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
         for ts in self.getInputTs():
             self._insertFunctionStep(self.convertInputStep, ts.getObjId())
             self._insertFunctionStep(self.computeDefocusStep, ts.getObjId())
-            self._insertFunctionStep(self.triggerReconstructionProtocolStep)
+        self._insertFunctionStep(self.triggerReconstructionProtocolStep)
 
     # --------------------------- STEPS functions -----------------------------
     def convertInputStep(self, tsObjId):

--- a/novactf/protocols/protocol_tomoDefocus.py
+++ b/novactf/protocols/protocol_tomoDefocus.py
@@ -1,4 +1,4 @@
-# **************************************************************************
+# *****************************************************************************
 # *
 # * Authors:     Federico P. de Isidro Gomez (fp.deisidro@cnb.csic.es) [1]
 # *
@@ -22,19 +22,19 @@
 # *  All comments concerning this program package may be sent to the
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
-# **************************************************************************
+# *****************************************************************************
 
 import os
+from glob import glob
 
 from pyworkflow import BETA
 import pyworkflow.protocol.params as params
-from pyworkflow.project import Manager
 import pyworkflow.utils.path as path
 from pyworkflow.protocol.constants import STEPS_PARALLEL
 from pyworkflow.object import Integer, List
+from pwem.emlib.image import ImageHandler
 from pwem.protocols import EMProtocol
 from tomo.protocols import ProtTomoBase
-from pwem.emlib.image import ImageHandler
 
 from imod import utils as imodUtils
 from .. import Plugin
@@ -42,20 +42,19 @@ from .. import Plugin
 
 class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
     """
-    Defocus estimation of each tilt-image procedure based on the novaCTF procedure.
+    Compute defocus array for each tilt-image with novaCTF.
 
     More info:
             https://github.com/turonova/novaCTF
     """
 
-    _label = 'tomo ctf defocus'
+    _label = 'compute defocus array'
     _devStatus = BETA
 
     def __init__(self, **args):
         EMProtocol.__init__(self, **args)
         ProtTomoBase.__init__(self)
         self.stepsExecutionMode = STEPS_PARALLEL
-        self.numberOfIntermediateStacks = List([])
 
     # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):
@@ -64,101 +63,73 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
         form.addParam('inputSetOfTiltSeries',
                       params.PointerParam,
                       pointerClass='SetOfTiltSeries',
-                      label='Input set of tilt-Series')
+                      label='Input set of tilt-series')
 
         form.addParam('inputSetOfCtfTomoSeries',
                       params.PointerParam,
-                      label="input tilt-series CTF estimation",
+                      label="Input tilt-series CTF estimation",
                       pointerClass='SetOfCTFTomoSeries',
-                      help='Select the CTF estimation from the set of tilt-series.')
+                      help='Select the CTF estimation for the input tilt-series.')
 
         form.addParam('tomoThickness',
                       params.FloatParam,
-                      default=100,
+                      default=400,
                       label='Tomogram thickness (voxels)',
-                      important=True,
                       display=params.EnumParam.DISPLAY_HLIST,
-                      help='Size in voxels of the tomogram in the z axis (beam direction).')
+                      help='Size of the tomogram in voxels in the Z direction.')
 
         form.addParam('tomoShift',
                       params.FloatParam,
                       default=0,
                       label='Tomogram shift (voxels)',
-                      important=True,
                       display=params.EnumParam.DISPLAY_HLIST,
-                      help='Shift in voxels of the tomogram in the z axis (beam direction).')
+                      help='Shift of the tomogram in voxels in the Z direction. '
+                           'The shift should be set to zero even if for '
+                           'reconstruction we want to shift the tomogram in z! '
+                           'We assume the defocus to be estimated at the center '
+                           'of mass which should correspond to the shifted '
+                           'tomogram and thus here the shift should be zero.')
 
         form.addParam('defocusStep',
                       params.IntParam,
                       default=15,
                       label='Defocus step (nm)',
-                      important=True,
                       display=params.EnumParam.DISPLAY_HLIST,
-                      help='Minimum defocus difference used for reconstruction in nanometers.')
+                      help='The space between min and max in Z is sliced '
+                           'by defocus step. 15 nm is default step size. '
+                           'See Fig. 2 in Turonova et al., 2017 for optimal number.')
 
         form.addParam('correctionType',
                       params.EnumParam,
                       choices=['Phase flip', 'Multiplication'],
                       default=0,
                       label='Correction type',
-                      important=True,
                       display=params.EnumParam.DISPLAY_HLIST,
-                      help='Correction type to be applied for reconstruction')
+                      help='CTF correction type to be applied for the tilt-series.')
 
         form.addParam('correctAstigmatism',
                       params.EnumParam,
-                      choices=['Yes', 'No'],
-                      default=0,
+                      choices=['No', 'Yes'],
+                      default=1,
                       label='Correct astigmatism',
-                      important=True,
                       display=params.EnumParam.DISPLAY_HLIST,
-                      help='Correct for astigmatism in reconstruction')
-
-        self.defineFilterParameters(form)
+                      help='Correct for astigmatism in reconstruction.')
 
         form.addParallelSection(threads=8, mpi=1)
 
-    @staticmethod
-    def defineFilterParameters(form):
-        groupRadialFrequencies = form.addGroup('Radial filtering',
-                                               help='This entry controls low-pass filtering with the radial weighting '
-                                                    'function.  The radial weighting function is linear away from the '
-                                                    'origin out to the distance in reciprocal space specified by the '
-                                                    'first value, followed by a Gaussian fall-off determined by the '
-                                                    'second value.')
-        groupRadialFrequencies.addParam('radialFirstParameter',
-                                        params.FloatParam,
-                                        default=0.3,
-                                        label='First parameter',
-                                        help='Linear region value')
-        groupRadialFrequencies.addParam('radialSecondParameter',
-                                        params.FloatParam,
-                                        default=0.05,
-                                        label='Second parameter',
-                                        help='Gaussian fall-off parameter')
-
-    # -------------------------- INSERT steps functions ---------------------
+    # -------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):
         self.numberOfIntermediateStacks = List([])
+        for ts in self.getInputTs():
+            self._insertFunctionStep(self.convertInputStep, ts.getObjId())
+            self._insertFunctionStep(self.computeDefocusStep, ts.getObjId())
 
-        for ts in self.inputSetOfTiltSeries.get():
-            self._insertFunctionStep(self.convertInputStep,
-                                     ts.getObjId())
-
-            self._insertFunctionStep(self.computeDefocusStep,
-                                     ts.getObjId())
-
-            self._insertFunctionStep(self.getNumberOfIntermediateStacksStep,
-                                     ts.getObjId())
-
-        self._insertFunctionStep(self.triggerReconstructionProtocolStep)
-
-    # --------------------------- STEPS functions ----------------------------
+    # --------------------------- STEPS functions -----------------------------
     def convertInputStep(self, tsObjId):
-        ts = self.inputSetOfTiltSeries.get()[tsObjId]
+        ts = self.getInputTs()[tsObjId]
         tsId = ts.getTsId()
 
-        ctfTomoSeries = self.getCtfTomoSeriesFromTsId(self.inputSetOfCtfTomoSeries.get(), tsId)
+        ctfTomoSeries = self.getCtfTomoSeriesFromTsId(tsId)
 
         tmpPrefix = self._getTmpPath(tsId)
         extraPrefix = self._getExtraPath(tsId)
@@ -168,16 +139,18 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
 
         firstItem = ts.getFirstItem()
 
-        """Generate angle file"""
-        angleFilePath = os.path.join(tmpPrefix, firstItem.parseFileName(extension=".tlt"))
+        # Generate angle file
+        angleFilePath = os.path.join(tmpPrefix,
+                                     firstItem.parseFileName(extension=".tlt"))
         ts.generateTltFile(angleFilePath)
 
-        """Generate defocus file"""
-        defocusFilePath = os.path.join(extraPrefix, firstItem.parseFileName(extension=".defocus"))
+        # Generate defocus file
+        defocusFilePath = os.path.join(extraPrefix,
+                                       firstItem.parseFileName(extension=".defocus"))
         imodUtils.generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath)
 
     def computeDefocusStep(self, tsObjId):
-        ts = self.inputSetOfTiltSeries.get()[tsObjId]
+        ts = self.getInputTs()[tsObjId]
         tsId = ts.getTsId()
 
         tmpPrefix = self._getTmpPath(ts.getTsId())
@@ -186,9 +159,14 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
         firstItem = ts.getFirstItem()
 
         ih = ImageHandler()
-        xDim, yDim, _, _ = ih.getDimensions(firstItem.getFileName()+":mrc")
+        xDim, yDim, _, _ = ih.getDimensions(firstItem.getFileName() + ":mrc")
 
-        defocusFilePath = os.path.join(extraPrefix, firstItem.parseFileName(extension=".defocus"))
+        defocusFilePath = os.path.join(extraPrefix,
+                                       firstItem.parseFileName(extension=".defocus"))
+
+        defocusShift = self.tomoThickness.get() / 2 + self.tomoShift.get()
+        with open(defocusFilePath.replace(".defocus", ".def_shift"), "w") as fn:
+            fn.write(f"{defocusShift}")
 
         paramsDefocus = {
             'Algorithm': "defocus",
@@ -196,13 +174,13 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
             'FullImage': str(xDim) + "," + str(yDim),
             'Thickness': self.tomoThickness.get(),
             'TiltFile': os.path.join(tmpPrefix, firstItem.parseFileName(extension=".tlt")),
-            'Shift': "0.0," + str(self.tomoShift.get()),
-            'CorrectionType': self.getCorrectionType(),
+            'CorrectionType': "phaseflip" if self.correctionType == 0 else "multiplication",
             'DefocusFileFormat': "imod",
             'CorrectAstigmatism': self.correctAstigmatism.get(),
             'DefocusFile': defocusFilePath,
-            'PixelSize': self.inputSetOfTiltSeries.get().getSamplingRate() / 10,
-            'DefocusStep': self.defocusStep.get()
+            'PixelSize': self.getInputTs().getSamplingRate() / 10,
+            'DefocusStep': self.defocusStep.get(),
+            'DefocusShiftFile': defocusFilePath.replace(".defocus", ".def_shift")
         }
 
         argsDefocus = "-Algorithm %(Algorithm)s " \
@@ -210,112 +188,48 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
                       "-FULLIMAGE %(FullImage)s " \
                       "-THICKNESS %(Thickness)d " \
                       "-TILTFILE %(TiltFile)s " \
-                      "-SHIFT %(Shift)s " \
+                      "-SHIFT 0.0,0.0 " \
                       "-CorrectionType %(CorrectionType)s " \
                       "-DefocusFileFormat %(DefocusFileFormat)s " \
                       "-CorrectAstigmatism %(CorrectAstigmatism)d " \
                       "-DefocusFile %(DefocusFile)s " \
                       "-PixelSize %(PixelSize)s " \
-                      "-DefocusStep %(DefocusStep)d"
+                      "-DefocusStep %(DefocusStep)d " \
+                      "-DefocusShiftFile %(DefocusShiftFile)s "
 
         Plugin.runNovactf(self, 'novaCTF', argsDefocus % paramsDefocus)
 
-    def getNumberOfIntermediateStacksStep(self, tsObjId):
-        ts = self.inputSetOfTiltSeries.get()[tsObjId]
-
-        extraPrefix = self._getExtraPath(ts.getTsId())
-
-        defocusFilePath = os.path.join(extraPrefix,
-                                       ts.getFirstItem().parseFileName(extension=".defocus_"))
-        numberOfIntermediateStacks = 0
-
-        counter = 0
-        while os.path.exists(defocusFilePath + str(counter)):
-            numberOfIntermediateStacks += 1
-            counter += 1
-
-        self.numberOfIntermediateStacks.append(Integer(numberOfIntermediateStacks))
-
-    def triggerReconstructionProtocolStep(self):
-        # Local import to avoid looping
-        from . import ProtNovaCtfTomoReconstruction
-
-        manager = Manager()
-        project = manager.loadProject(self.getProject().getName())
-
-        protTomoReconstruction = ProtNovaCtfTomoReconstruction()
-        protTomoReconstruction.setObjLabel('novactf - tomo ctf reconstruction')
-        protTomoReconstruction.protTomoCtfDefocus.set(self)
-        protTomoReconstruction.radialFirstParameter.set(self.radialFirstParameter.get())
-        protTomoReconstruction.radialSecondParameter.set(self.radialSecondParameter.get())
-        protTomoReconstruction.numberOfThreads.set(self.numberOfThreads.get())
-        protTomoReconstruction.numberOfMpi.set(self.numberOfMpi.get())
-
-        project.scheduleProtocol(protTomoReconstruction)
+        files = glob(defocusFilePath.replace(".defocus", ".defocus_*"))
+        self.numberOfIntermediateStacks.append(Integer(len(files)))
 
         self._store()
 
-    # --------------------------- UTILS functions ----------------------------
-    def getCtfTomoSeriesFromTsId(self, setOfCtfTomoSeries, tsId):
-        for ctfTomoSeries in self.inputSetOfCtfTomoSeries.get():
-            if tsId == ctfTomoSeries.getTsId():
-                return ctfTomoSeries
-
-    def getCorrectionType(self):
-        if self.correctionType.get() == 0:
-            correctionType = "phaseflip"
-        elif self.correctionType.get() == 1:
-            correctionType = "multiplication"
-
-        return correctionType
-
-    # --------------------------- INFO functions ----------------------------
+    # --------------------------- INFO functions ------------------------------
     def _validate(self):
         validateMsgs = []
 
-        if self.inputSetOfTiltSeries.get().getSize() != self.inputSetOfCtfTomoSeries.get().getSize():
-            validateMsgs.append("Input set of tilt-series and input set of CTF tomo estimations must contain the "
-                                "same number of elements.")
+        if self.getInputTs().getSize() != self.inputSetOfCtfTomoSeries.get().getSize():
+            validateMsgs.append("Input set of tilt-series and input set of CTFs "
+                                " must contain the same number of items.")
 
         return validateMsgs
 
     def _summary(self):
         summary = []
 
-        counter = 0
-
-        for ts in self.inputSetOfTiltSeries.get():
-            tsId = ts.getTsId()
-            if os.path.exists(os.path.join(self._getExtraPath(tsId), tsId + ".defocus_0")):
-                counter += 1
-
-        if counter != 0:
-            summary.append("Input Tilt-Series: %d.\n"
-                           "Tilt-series defocus processed: %d.\n"
-                           "Defocus files generated for each tilt-series: %d.\n"
-                           % (self.inputSetOfTiltSeries.get().getSize(),
-                              counter,
-                              self.numberOfIntermediateStacks[0]))
+        if len(self.numberOfIntermediateStacks):
+            summary.append(f"Input tilt-series: {self.getInputTs().getSize()}\n"
+                           f"Defocus files generated for each tilt-series: "
+                           f"{self.numberOfIntermediateStacks[0]}")
         else:
-            summary.append("Output not ready yet.")
+            summary.append("Outputs are not ready yet.")
         return summary
 
-    def _methods(self):
-        methods = []
+    # --------------------------- UTILS functions -----------------------------
+    def getInputTs(self):
+        return self.inputSetOfTiltSeries.get()
 
-        counter = 0
-
-        for ts in self.inputSetOfTiltSeries.get():
-            tsId = ts.getTsId()
-            if os.path.exists(os.path.join(self._getExtraPath(tsId), tsId + ".defocus_0")):
-                counter += 1
-
-        if counter != 0:
-            methods.append("%d defocus files have been generated for each of the %d tilt-series using the defocus "
-                           "algorithm from novaCTF.\n"
-                           % (self.numberOfIntermediateStacks[0],
-                              counter))
-        else:
-            methods.append("Output not ready yet.")
-
-        return methods
+    def getCtfTomoSeriesFromTsId(self, tsId):
+        for ctfTomoSeries in self.inputSetOfCtfTomoSeries.get():
+            if tsId == ctfTomoSeries.getTsId():
+                return ctfTomoSeries

--- a/novactf/protocols/protocol_tomoDefocus.py
+++ b/novactf/protocols/protocol_tomoDefocus.py
@@ -170,11 +170,11 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
 
         paramsDefocus = {
             'Algorithm': "defocus",
-            'InputProjections': firstItem.getLocation()[1],
+            'InputProjections': firstItem.getFileName(),
             'FullImage': str(xDim) + "," + str(yDim),
             'Thickness': self.tomoThickness.get(),
             'TiltFile': os.path.join(tmpPrefix, firstItem.parseFileName(extension=".tlt")),
-            'CorrectionType': "phaseflip" if self.correctionType == 0 else "multiplication",
+            'CorrectionType': "phaseflip" if self.correctionType.get() == 0 else "multiplication",
             'DefocusFileFormat': "imod",
             'CorrectAstigmatism': self.correctAstigmatism.get(),
             'DefocusFile': defocusFilePath,

--- a/novactf/protocols/protocol_tomoDefocus.py
+++ b/novactf/protocols/protocol_tomoDefocus.py
@@ -212,6 +212,10 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
             validateMsgs.append("Input set of tilt-series and input set of CTFs "
                                 " must contain the same number of items.")
 
+        defFlag = self.inputSetOfCtfTomoSeries.get().getIMODDefocusFileFlag()
+        if defFlag in [0, 4] and self.correctAstigmatism.get() == 1:
+            validateMsgs.append("CTF estimation does not have astigmatism values.")
+
         return validateMsgs
 
     def _summary(self):

--- a/novactf/protocols/protocol_tomoDefocus.py
+++ b/novactf/protocols/protocol_tomoDefocus.py
@@ -166,9 +166,10 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
         defocusFilePath = os.path.join(extraPrefix,
                                        firstItem.parseFileName(extension=".defocus"))
 
-        defocusShift = self.tomoThickness.get() / 2 + self.tomoShift.get()
-        with open(defocusFilePath.replace(".defocus", ".def_shift"), "w") as fn:
-            fn.write(f"{defocusShift}")
+        if self.tomoShift.get() > 0.01:
+            defocusShift = self.tomoThickness.get() / 2 + self.tomoShift.get()
+            with open(defocusFilePath.replace(".defocus", ".def_shift"), "w") as fn:
+                fn.write(f"{defocusShift}")
 
         paramsDefocus = {
             'Algorithm': "defocus",
@@ -196,8 +197,10 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
                       "-CorrectAstigmatism %(CorrectAstigmatism)d " \
                       "-DefocusFile %(DefocusFile)s " \
                       "-PixelSize %(PixelSize)s " \
-                      "-DefocusStep %(DefocusStep)d " \
-                      "-DefocusShiftFile %(DefocusShiftFile)s "
+                      "-DefocusStep %(DefocusStep)d "
+
+        if self.tomoShift.get() > 0.01:
+            argsDefocus += "-DefocusShiftFile %(DefocusShiftFile)s "
 
         Plugin.runNovactf(self, 'novaCTF', argsDefocus % paramsDefocus)
 

--- a/novactf/protocols/protocol_tomoDefocus.py
+++ b/novactf/protocols/protocol_tomoDefocus.py
@@ -212,9 +212,11 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
             validateMsgs.append("Input set of tilt-series and input set of CTFs "
                                 " must contain the same number of items.")
 
-        defFlag = self.inputSetOfCtfTomoSeries.get().getIMODDefocusFileFlag()
-        if defFlag in [0, 4] and self.correctAstigmatism.get() == 1:
-            validateMsgs.append("CTF estimation does not have astigmatism values.")
+        ctf = self.inputSetOfCtfTomoSeries.get().getFirstItem()
+        if hasattr(ctf, "_IMODDefocusFileFlag"):
+            defFlag = ctf.getIMODDefocusFileFlag()
+            if defFlag in [0, 4] and self.correctAstigmatism.get() == 1:
+                validateMsgs.append("CTF estimation does not have astigmatism values.")
 
         return validateMsgs
 

--- a/novactf/protocols/protocol_tomoDefocus.py
+++ b/novactf/protocols/protocol_tomoDefocus.py
@@ -115,7 +115,7 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
                       display=params.EnumParam.DISPLAY_HLIST,
                       help='Correct for astigmatism in reconstruction.')
 
-        form.addParallelSection(threads=8, mpi=1)
+        form.addParallelSection(threads=2, mpi=1)
 
     # -------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):
@@ -226,7 +226,9 @@ class ProtNovaCtfTomoDefocus(EMProtocol, ProtTomoBase):
         if len(self.numberOfIntermediateStacks):
             summary.append(f"Input tilt-series: {self.getInputTs().getSize()}\n"
                            f"Defocus files generated for each tilt-series: "
-                           f"{self.numberOfIntermediateStacks[0]}")
+                           f"{self.numberOfIntermediateStacks[0]}\n\n"
+                           "Use this protocol as input for novaCTF - 3D CTF "
+                           "correction and reconstruction.")
         else:
             summary.append("Outputs are not ready yet.")
         return summary

--- a/novactf/protocols/protocol_tomoReconstruction.py
+++ b/novactf/protocols/protocol_tomoReconstruction.py
@@ -168,6 +168,12 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
                                          firstItem.parseFileName(extension=".tlt"))
         ts.generateTltFile(outputTltFileName)
 
+        if firstItem.hasTransform():
+            # Generate transformation matrices file
+            outputTmFileName = os.path.join(tmpPrefix,
+                                            firstItem.parseFileName(extension=".xf"))
+            imodUtils.formatTransformFile(ts, outputTmFileName)
+
     def processIntermediateStacksStep(self, tsObjId, counter):
 
         with self._lock:
@@ -220,17 +226,13 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
 
         # Alignment step
         if self.applyAlignment and firstItem.hasTransform():
-            # Generate transformation matrices file
-            outputTmFileName = os.path.join(tmpPrefix,
-                                            firstItem.parseFileName(extension=".xf"))
-            imodUtils.formatTransformFile(ts, outputTmFileName)
-
             paramsAlignment = {
                 'input': currentFn,
                 'output': os.path.join(tmpPrefix,
                                        firstItem.parseFileName(suffix="_ali",
                                                                extension=".mrc_")) + str(counter),
-                'xform': outputTmFileName,
+                'xform': os.path.join(tmpPrefix,
+                                      firstItem.parseFileName(extension=".xf"))
             }
 
             argsAlignment = "-input %(input)s " \

--- a/novactf/protocols/protocol_tomoReconstruction.py
+++ b/novactf/protocols/protocol_tomoReconstruction.py
@@ -136,7 +136,7 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
                 intermediateStacksId.append(ctfId)
 
             reconstructionId = self._insertFunctionStep(self.computeReconstructionStep,
-                                                        ts.getObjId(),
+                                                        ts.getObjId(), nstacks[index].get(),
                                                         prerequisites=intermediateStacksId)
 
             createOutputId = self._insertFunctionStep(self.createOutputStep,
@@ -257,7 +257,7 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
                                      firstItem.parseFileName(suffix="_ali",
                                                              extension=".mrc_")) + str(counter)
 
-        # Erase gold step
+        # Erase gold step  # TODO: fixme
         if self.doEraseGold:
             lm = self.inputSetOfLandmarkModels.get().getLandmarkModelFromTsId(tsId=tsId)
 
@@ -334,7 +334,7 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
 
         Plugin.runNovactf(self, 'novaCTF', argsFilterProjections % paramsFilterProjections)
 
-    def computeReconstructionStep(self, tsObjId):
+    def computeReconstructionStep(self, tsObjId, nstacks):
         with self._lock:
             ts = self.getInputTs()[tsObjId]
             firstItem = ts.getFirstItem()
@@ -359,7 +359,7 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
             'Thickness': self.protTomoCtfDefocus.get().tomoThickness.get(),
             'Shift': "0.0," + str(self.protTomoCtfDefocus.get().tomoShift.get()),
             'PixelSize': self.getInputTs().getSamplingRate() / 10,
-            'DefocusStep': self.protTomoCtfDefocus.get().defocusStep.get()
+            'NumberOfStacks': nstacks
         }
 
         args3dctf = "-Algorithm %(Algorithm)s " \
@@ -370,7 +370,7 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
                     "-THICKNESS %(Thickness)d " \
                     "-SHIFT %(Shift)s " \
                     "-PixelSize %(PixelSize)f " \
-                    "-DefocusStep %(DefocusStep)d " \
+                    "-NumberOfInputStacks %(NumberOfStacks)d " \
                     "-Use3DCTF 1 "
 
         # Check if rotation angle is greater than 45º.

--- a/novactf/protocols/protocol_tomoReconstruction.py
+++ b/novactf/protocols/protocol_tomoReconstruction.py
@@ -364,6 +364,7 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
         with self._lock:
             ts = self.getInputTs()[tsObjId]
             firstItem = ts.getFirstItem()
+            acq = ts.getAcquisition()
 
         tsId = ts.getTsId()
         extraPrefix = self._getExtraPath(tsId)
@@ -379,12 +380,11 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
 
             # Set default tomogram origin
             newTomogram.setOrigin(newOrigin=None)
-            newTomogram.setAcquisition(ts.getAcquisition())
+            newTomogram.setAcquisition(acq)
 
             outputTomos.append(newTomogram)
-
-        outputTomos.write()
-        self._store()
+            outputTomos.write()
+            self._store()
 
     def closeOutputSetsStep(self):
         self.getOutputSetOfTomograms().setStreamState(Set.STREAM_CLOSED)

--- a/novactf/protocols/protocol_tomoReconstruction.py
+++ b/novactf/protocols/protocol_tomoReconstruction.py
@@ -339,9 +339,7 @@ class ProtNovaCtfTomoReconstruction(EMProtocol, ProtTomoBase):
         rotationAngle = ts.getAcquisition().getTiltAxisAngle()
 
         if 45 < abs(rotationAngle) < 135:
-            params3dctf.update({
-                'FullImage': "%d,%d" % (firstItem.getYDim(), firstItem.getXDim())
-            })
+            params3dctf['FullImage'] = "%d,%d" % (firstItem.getYDim(), firstItem.getXDim())
 
         Plugin.runNovactf(self, 'novaCTF', args3dctf % params3dctf)
 

--- a/novactf/tests/test_protocols_novactf.py
+++ b/novactf/tests/test_protocols_novactf.py
@@ -63,35 +63,13 @@ class TestNovaCtfBase(BaseTest):
         return cls.protImportTS
 
     @classmethod
-    def _runCTFEstimation(cls, inputSoTS, defocusTol, expectedDefocusOrigin, expectedDefocusValue,
-                          axisAngle, leftDefTol, rightDefTol, tileSize, angleStep, angleRange,
-                          startFreq, endFreq, extraZerosToFit, skipAstigmaticViews, searchAstigmatism,
-                          findAstigPhaseCutonToggle, phaseShiftAstigmatism, cutOnFrequencyAstigmatism,
-                          minimumViewsAstigmatism, minimumViewsPhaseShift, numberSectorsAstigmatism,
-                          maximumAstigmatism):
+    def _runCTFEstimation(cls, inputSoTS, expectedDefocusOrigin,
+                          expectedDefocusValue,searchAstigmatism):
         cls.protCTFEstimation = cls.newProtocol(imod.protocols.ProtImodAutomaticCtfEstimation,
                                                 inputSet=inputSoTS,
-                                                defocusTol=defocusTol,
                                                 expectedDefocusOrigin=expectedDefocusOrigin,
                                                 expectedDefocusValue=expectedDefocusValue,
-                                                axisAngle=axisAngle,
-                                                leftDefTol=leftDefTol,
-                                                rightDefTol=rightDefTol,
-                                                tileSize=tileSize,
-                                                angleStep=angleStep,
-                                                angleRange=angleRange,
-                                                startFreq=startFreq,
-                                                endFreq=endFreq,
-                                                extraZerosToFit=extraZerosToFit,
-                                                skipAstigmaticViews=skipAstigmaticViews,
-                                                searchAstigmatism=searchAstigmatism,
-                                                findAstigPhaseCutonToggle=findAstigPhaseCutonToggle,
-                                                phaseShiftAstigmatism=phaseShiftAstigmatism,
-                                                cutOnFrequencyAstigmatism=cutOnFrequencyAstigmatism,
-                                                minimumViewsAstigmatism=minimumViewsAstigmatism,
-                                                minimumViewsPhaseShift=minimumViewsPhaseShift,
-                                                numberSectorsAstigmatism=numberSectorsAstigmatism,
-                                                maximumAstigmatism=maximumAstigmatism)
+                                                searchAstigmatism=searchAstigmatism)
 
         cls.launchProtocol(cls.protCTFEstimation)
 
@@ -139,36 +117,18 @@ class TestNovaCtfReconstructionWorkflow(TestNovaCtfBase):
 
         cls.protCTFEstimation = cls._runCTFEstimation(
             inputSoTS=cls.protImportTS.outputTiltSeries,
-            defocusTol=200.0,
             expectedDefocusOrigin=0,
             expectedDefocusValue=6000,
-            axisAngle=0.0,
-            leftDefTol=2000.0,
-            rightDefTol=2000.0,
-            tileSize=256,
-            angleStep=2.0,
-            angleRange=20.0,
-            startFreq=0.0,
-            endFreq=0.0,
-            extraZerosToFit=0.0,
-            skipAstigmaticViews=1,
-            searchAstigmatism=1,
-            findAstigPhaseCutonToggle=1,
-            phaseShiftAstigmatism=0,
-            cutOnFrequencyAstigmatism=0,
-            minimumViewsAstigmatism=3,
-            minimumViewsPhaseShift=1,
-            numberSectorsAstigmatism=36,
-            maximumAstigmatism=1.2)
+            searchAstigmatism=0)
 
         cls.protCTFCompute = cls._runComputeCtfArray(
             inputSetOfTiltSeries=cls.protImportTS.outputTiltSeries,
             inputSetOfCtfTomoSeries=cls.protCTFEstimation.CTFTomoSeries,
             tomoThickness=20,
             tomoShift=0,
-            defocusStep=15,
+            defocusStep=50,
             correctionType=0,
-            correctAstigmatism=1)
+            correctAstigmatism=0)
 
         cls.protReconstruct = cls.newProtocol(ProtNovaCtfTomoReconstruction,
                                               protTomoCtfDefocus=cls.protCTFCompute,

--- a/novactf/tests/test_protocols_novactf.py
+++ b/novactf/tests/test_protocols_novactf.py
@@ -39,19 +39,16 @@ class TestNovaCtfBase(BaseTest):
         setupTestProject(cls)
 
     @classmethod
-    def _runImportTiltSeries(cls, filesPath, pattern, voltage, magnification, sphericalAberration, amplitudeContrast,
-                             samplingRate, doseInitial, dosePerFrame, anglesFrom=0, minAngle=0.0, maxAngle=0.0,
-                             stepAngle=1.0, tiltAxisAngle=87.2):
+    def _runImportTiltSeries(cls, filesPath, pattern, voltage, magnification,
+                             samplingRate, dosePerFrame, anglesFrom=0, minAngle=0.0, maxAngle=0.0,
+                             stepAngle=1.0, tiltAxisAngle=0.0):
         cls.protImportTS = cls.newProtocol(tomo.protocols.ProtImportTs,
                                            filesPath=filesPath,
                                            filesPattern=pattern,
                                            voltage=voltage,
                                            anglesFrom=anglesFrom,
                                            magnification=magnification,
-                                           sphericalAberration=sphericalAberration,
-                                           amplitudeContrast=amplitudeContrast,
                                            samplingRate=samplingRate,
-                                           doseInitial=doseInitial,
                                            dosePerFrame=dosePerFrame,
                                            minAngle=minAngle,
                                            maxAngle=maxAngle,
@@ -63,12 +60,13 @@ class TestNovaCtfBase(BaseTest):
         return cls.protImportTS
 
     @classmethod
-    def _runCTFEstimation(cls, inputSoTS, expectedDefocusOrigin,
-                          expectedDefocusValue,searchAstigmatism):
+    def _runCTFEstimation(cls, inputSoTS, expectedDefocusOrigin, angleRange,
+                          expectedDefocusValue, searchAstigmatism):
         cls.protCTFEstimation = cls.newProtocol(imod.protocols.ProtImodAutomaticCtfEstimation,
                                                 inputSet=inputSoTS,
                                                 expectedDefocusOrigin=expectedDefocusOrigin,
                                                 expectedDefocusValue=expectedDefocusValue,
+                                                angleRange=angleRange,
                                                 searchAstigmatism=searchAstigmatism)
 
         cls.launchProtocol(cls.protCTFEstimation)
@@ -106,19 +104,18 @@ class TestNovaCtfReconstructionWorkflow(TestNovaCtfBase):
             anglesFrom=0,
             voltage=300,
             magnification=50000,
-            sphericalAberration=2.7,
-            amplitudeContrast=0.07,
             samplingRate=8.8,
-            doseInitial=0,
             dosePerFrame=0.3,
             minAngle=-60.0,
             maxAngle=60.0,
-            stepAngle=3.0)
+            stepAngle=3.0,
+            tiltAxisAngle=2.8)
 
         cls.protCTFEstimation = cls._runCTFEstimation(
             inputSoTS=cls.protImportTS.outputTiltSeries,
             expectedDefocusOrigin=0,
             expectedDefocusValue=6000,
+            angleRange=20,
             searchAstigmatism=0)
 
         cls.protCTFCompute = cls._runComputeCtfArray(


### PR DESCRIPTION
To be merged after #39 

- fix defocus shift: should be passed in a file for ctf correction, and as a param for reconstruction
- stack is aligned after ctf correction
- fix test tilt axis value
- add astigmatism validation
- do not create new TomoAcquisition object
- use mrc extension for all files